### PR TITLE
TW-2466: Fix turbolinks navigation

### DIFF
--- a/app/assets/javascripts/pages/data.js
+++ b/app/assets/javascripts/pages/data.js
@@ -20,5 +20,4 @@ midhack.ready = function() {
   }
 };
 
-$(document).ready(midhack.ready);
 $(document).on('turbolinks:load', midhack.ready);


### PR DESCRIPTION
"[turbolinks] fires once on the initial page load and again after every Turbolinks visit." Document ready borde alltså inte behövas och detta verkar lösa problemet. 